### PR TITLE
Use ? operator replace unwrap to handle error

### DIFF
--- a/src/handlers/handle_create_service.rs
+++ b/src/handlers/handle_create_service.rs
@@ -43,7 +43,7 @@ pub async fn handle_create_service(
         .expect("Failed to stringify file name")
         .to_string();
 
-    let service_name = custom_name.unwrap_or(file_name.to_string());
+    let service_name = custom_name.unwrap_or_else(|| file_name.to_string());
     let full_service_name = get_full_service_name(&service_name);
 
     // Create file if it doesn't exist
@@ -102,7 +102,7 @@ pub async fn handle_create_service(
                 .unwrap();
         }
 
-        handle_show_status().await.unwrap();
+        handle_show_status().await?;
     }
 
     Ok(())

--- a/src/handlers/handle_delete_service.rs
+++ b/src/handlers/handle_delete_service.rs
@@ -24,7 +24,7 @@ pub async fn handle_delete_service(name: String) -> Result<(), Box<dyn std::erro
 
     println!("Deleted {service_file_path_str}");
 
-    handle_show_status().await.unwrap();
+    handle_show_status().await?;
 
     Ok(())
 }

--- a/src/handlers/handle_disable_service.rs
+++ b/src/handlers/handle_disable_service.rs
@@ -13,18 +13,18 @@ pub async fn handle_disable_service(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let full_service_name = get_full_service_name(&name);
 
-    let connection = zbus::Connection::system().await.unwrap();
-    let manager_proxy = ManagerProxy::new(&connection).await.unwrap();
+    let connection = zbus::Connection::system().await?;
+    let manager_proxy = ManagerProxy::new(&connection).await?;
 
     disable_service(&manager_proxy, &full_service_name).await;
 
     // Reload necessary for UnitFileState to update
-    manager_proxy.reload().await.unwrap();
+    manager_proxy.reload().await?;
 
     println!("Disabled {name}");
 
     if show_status {
-        handle_show_status().await.unwrap();
+        handle_show_status().await?;
     }
 
     Ok(())

--- a/src/handlers/handle_enable_service.rs
+++ b/src/handlers/handle_enable_service.rs
@@ -13,18 +13,18 @@ pub async fn handle_enable_service(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let full_service_name = get_full_service_name(&name);
 
-    let connection = zbus::Connection::system().await.unwrap();
-    let manager_proxy = ManagerProxy::new(&connection).await.unwrap();
+    let connection = zbus::Connection::system().await?;
+    let manager_proxy = ManagerProxy::new(&connection).await?;
 
     enable_service(&manager_proxy, &full_service_name).await;
 
     // Reload necessary for UnitFileState to update
-    manager_proxy.reload().await.unwrap();
+    manager_proxy.reload().await?;
 
     println!("Enabled {name}");
 
     if show_status {
-        handle_show_status().await.unwrap();
+        handle_show_status().await?;
     }
 
     Ok(())

--- a/src/handlers/handle_start_service.rs
+++ b/src/handlers/handle_start_service.rs
@@ -15,8 +15,8 @@ pub async fn handle_start_service(
     name: String,
     show_status: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let connection = zbus::Connection::system().await.unwrap();
-    let manager_proxy = ManagerProxy::new(&connection).await.unwrap();
+    let connection = zbus::Connection::system().await?;
+    let manager_proxy = ManagerProxy::new(&connection).await?;
 
     let full_service_name = get_full_service_name(&name);
 
@@ -31,7 +31,7 @@ pub async fn handle_start_service(
     };
 
     if show_status {
-        handle_show_status().await.unwrap();
+        handle_show_status().await?;
     }
 
     Ok(())

--- a/src/handlers/handle_stop_service.rs
+++ b/src/handlers/handle_stop_service.rs
@@ -17,14 +17,14 @@ pub async fn handle_stop_service(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let full_service_name = get_full_service_name(&name);
 
-    let connection = zbus::Connection::system().await.unwrap();
-    let manager_proxy = ManagerProxy::new(&connection).await.unwrap();
+    let connection = zbus::Connection::system().await?;
+    let manager_proxy = ManagerProxy::new(&connection).await?;
     stop_service(&manager_proxy, &full_service_name).await;
 
     println!("Stopped {name}");
 
     if show_status {
-        handle_show_status().await.unwrap();
+        handle_show_status().await?;
     }
 
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -158,42 +158,43 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             interpreter,
             env_vars,
             internal_args,
-        } => handle_create_service(
-            path,
-            name,
-            start,
-            enable,
-            auto_restart,
-            interpreter,
-            env_vars,
-            internal_args,
-        )
-        .await
-        .unwrap(),
+        } => {
+            handle_create_service(
+                path,
+                name,
+                start,
+                enable,
+                auto_restart,
+                interpreter,
+                env_vars,
+                internal_args,
+            )
+            .await?
+        }
 
-        Commands::Start { name } => handle_start_service(name, true).await.unwrap(),
+        Commands::Start { name } => handle_start_service(name, true).await?,
 
-        Commands::Stop { name } => handle_stop_service(name, true).await.unwrap(),
+        Commands::Stop { name } => handle_stop_service(name, true).await?,
 
-        Commands::Enable { name } => handle_enable_service(name, true).await.unwrap(),
+        Commands::Enable { name } => handle_enable_service(name, true).await?,
 
-        Commands::Disable { name } => handle_disable_service(name, true).await.unwrap(),
+        Commands::Disable { name } => handle_disable_service(name, true).await?,
 
-        Commands::Status {} => handle_show_status().await.unwrap(),
+        Commands::Status {} => handle_show_status().await?,
 
         Commands::Logs {
             name,
             lines,
             follow,
-        } => handle_show_logs(name, lines, follow).await.unwrap(),
+        } => handle_show_logs(name, lines, follow).await?,
 
-        Commands::Edit { name, editor } => handle_edit_service_file(name, editor).await.unwrap(),
+        Commands::Edit { name, editor } => handle_edit_service_file(name, editor).await?,
 
-        Commands::Cat { name } => handle_print_service_file(name).await.unwrap(),
+        Commands::Cat { name } => handle_print_service_file(name).await?,
 
-        Commands::Which { name } => handle_print_paths(name).await.unwrap(),
+        Commands::Which { name } => handle_print_paths(name).await?,
 
-        Commands::Delete { name } => handle_delete_service(name).await.unwrap(),
+        Commands::Delete { name } => handle_delete_service(name).await?,
     }
 
     Ok(())

--- a/src/utils/systemd.rs
+++ b/src/utils/systemd.rs
@@ -137,11 +137,10 @@ pub async fn get_main_pid(
 ) -> Result<u32, zbus::Error> {
     let object_path = get_unit_path(full_service_name);
 
-    let validated_object_path = zvariant::ObjectPath::try_from(object_path).unwrap();
+    let validated_object_path = zvariant::ObjectPath::try_from(object_path)?;
 
-    let service_proxy = ServiceProxy::new(connection, validated_object_path)
-        .await
-        .unwrap();
+    let service_proxy = ServiceProxy::new(connection, validated_object_path).await?;
+
     service_proxy.main_pid().await
 }
 


### PR DESCRIPTION
before:

```bash
$ ./target/release/servicer create index.js
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: "index.js is not a file"', src/main.rs:172:10
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

after:

```bash
$ ./target/release/servicer create index.js
Error: "index.js is not a file"
```